### PR TITLE
Add types exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   "exports": {
     ".": {
       "import": "./dist/html-to-ast.esm.js",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   }
 }


### PR DESCRIPTION
## What is problem

In JS environments, types export is required.
Currently, types are not exported. So When Someone import from this library, TS7016 (Couldn't find a declaration file for 'html-to-ast') error has occured.

## How to Fix

Add types export at package.json [Docs](https://www.typescriptlang.org/docs/handbook/modules/reference.html#example-explicit-types-condition)