### PR TITLE
Fix text parsing around HTML comments

### DIFF
--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -1,0 +1,13 @@
+import { parse } from './parse';
+
+describe('parse', () => {
+  it('preserves text nodes surrounding comments', () => {
+    const ast = parse('before<!-- comment -->after');
+
+    expect(ast).toEqual([
+      { type: 'text', content: 'before' },
+      { type: 'comment', comment: ' comment ' },
+      { type: 'text', content: 'after' },
+    ]);
+  });
+});

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -51,6 +51,36 @@ export const parse = (html: string, options: Partial<IOptions> = {}) => {
     const start = index + tag.length;
     const nextChar = html.charAt(start);
 
+    const appendTextNode = () => {
+      if (inComponent || nextChar === '<' || !nextChar) {
+        return;
+      }
+
+      const parentForText =
+        level === -1
+          ? result
+          : (arr[level] && Array.isArray(arr[level].children)
+              ? (arr[level].children as MaybeDoc[])
+              : undefined);
+
+      if (!parentForText) {
+        return;
+      }
+
+      const end = html.indexOf('<', start);
+      let content = html.slice(start, end === -1 ? undefined : end);
+      if (whitespaceRE.test(content)) {
+        content = ' ';
+      }
+
+      if ((end > -1 && level + parentForText.length >= 0) || content !== ' ') {
+        parentForText.push({
+          type: 'text',
+          content: content,
+        });
+      }
+    };
+
     let parent: MaybeDoc | MaybeDoc['children'];
 
     if (isComment) {
@@ -59,13 +89,15 @@ export const parse = (html: string, options: Partial<IOptions> = {}) => {
       // if we're at root, push new base node
       if (level < 0) {
         result.push(comment);
-        return result
+        appendTextNode();
+        return result;
       }
       parent = arr[level];
       if (parent && parent.children && Array.isArray(parent.children)) {
         parent.children.push(comment);
       }
-      return result
+      appendTextNode();
+      return result;
     }
 
     if (isOpen) {
@@ -118,34 +150,7 @@ export const parse = (html: string, options: Partial<IOptions> = {}) => {
         // move current up a level to match the end tag
         current = level === -1 ? (result as MaybeDoc) : arr[level];
       }
-      if (!inComponent && nextChar !== '<' && nextChar) {
-        // trailing text node
-        // if we're at the root, push a base text node. otherwise add as
-        // a child to the current node.
-        parent = level === -1 ? result : (arr[level].children as MaybeDoc[]);
-
-        // calculate correct end of the content slice in case there's
-        // no tag after the text node.
-        const end = html.indexOf('<', start);
-        let content = html.slice(start, end === -1 ? undefined : end);
-        // if a node is nothing but whitespace, collapse it as the spec states:
-        // https://www.w3.org/TR/html4/struct/text.html#h-9.1
-        if (whitespaceRE.test(content)) {
-          content = ' ';
-        }
-        // don't add whitespace-only text nodes if they would be trailing text nodes
-        // or if they would be leading whitespace-only text nodes:
-        //  * end > -1 indicates this is not a trailing text node
-        //  * leading node is when level is -1 and parent has length 0
-        if ((end > -1 && level + parent.length >= 0) || content !== ' ') {
-          if (parent && Array.isArray(parent)) {
-            parent.push({
-              type: 'text',
-              content: content,
-            });
-          }
-        }
-      }
+      appendTextNode();
     }
   });
 

--- a/src/stringify.test.ts
+++ b/src/stringify.test.ts
@@ -1,0 +1,19 @@
+import { parse } from './parse';
+import { stringify } from './stringify';
+import type { IDoc } from './types';
+
+describe('stringify', () => {
+  it('stringifies component nodes like regular tags', () => {
+    const html = '<MyWidget foo="bar"></MyWidget>';
+    const ast = parse(html, { components: { MyWidget: 'component' } });
+
+    expect(stringify(ast as unknown as IDoc[])).toBe(html);
+  });
+
+  it('supports self-closing components', () => {
+    const html = '<MyWidget foo="bar" />';
+    const ast = parse(html, { components: { MyWidget: 'component' } });
+
+    expect(stringify(ast as unknown as IDoc[])).toBe('<MyWidget foo="bar"/>');
+  });
+});

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -11,20 +11,27 @@ function attrString(attrs: Attr) {
   return ' ' + buff.join(' ');
 }
 
+function appendTagLike(buff: string, doc: IDoc): string {
+  buff +=
+    '<' +
+    doc.name +
+    (doc.attrs ? attrString(doc.attrs) : '') +
+    (doc.voidElement ? '/>' : '>');
+
+  if (doc.voidElement) {
+    return buff;
+  }
+
+  return buff + doc.children.reduce(_stringify, '') + '</' + doc.name + '>';
+}
+
 function _stringify(buff: string, doc: IDoc): string {
   switch (doc.type) {
     case 'text':
       return buff + doc.content;
     case 'tag':
-      buff +=
-        '<' +
-        doc.name +
-        (doc.attrs ? attrString(doc.attrs) : '') +
-        (doc.voidElement ? '/>' : '>');
-      if (doc.voidElement) {
-        return buff;
-      }
-      return buff + doc.children.reduce(_stringify, '') + '</' + doc.name + '>';
+    case 'component':
+      return appendTagLike(buff, doc);
     case 'comment':
       buff += '<!--' + doc.comment + '-->';
       return buff;


### PR DESCRIPTION
## Summary
- ensure the parser reuses a helper so text nodes following comments are preserved
- add a regression test that demonstrates text before and after a comment is returned
- treat component nodes the same as tag nodes during stringification so their markup is preserved
- add regression tests that cover stringifying both regular and self-closing components

## Testing
- npm test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69196e5320f88323b6b07356334ed12e)